### PR TITLE
Fix #4 - Make tests work on windows 

### DIFF
--- a/src/sbt-test/gzip/compress/build.sbt
+++ b/src/sbt-test/gzip/compress/build.sbt
@@ -8,7 +8,7 @@ val expected = Set(
   "css", "css/a.css", "css/a.css.gz",
   "js", "js/a.js", "js/a.js.gz",
   "images", "images/a.png", "images/b.jpg"
-)
+) map(_.replace("/", java.io.File.separator))
 
 val checkMappings = taskKey[Unit]("check the pipeline mappings")
 

--- a/src/sbt-test/gzip/exclude/build.sbt
+++ b/src/sbt-test/gzip/exclude/build.sbt
@@ -8,7 +8,10 @@ excludeFilter in gzip := "*.css"
 
 // for checking that the produced pipeline mappings are correct
 
-val expected = Set("css", "css/a.css", "js", "js/a.js", "js/a.js.gz")
+val expected = Set(
+  "css", "css/a.css",
+  "js", "js/a.js", "js/a.js.gz"
+) map(_.replace("/", java.io.File.separator))
 
 val checkMappings = taskKey[Unit]("check the pipeline mappings")
 

--- a/src/sbt-test/gzip/include/build.sbt
+++ b/src/sbt-test/gzip/include/build.sbt
@@ -8,7 +8,10 @@ includeFilter in gzip := "*.js"
 
 // for checking that the produced pipeline mappings are correct
 
-val expected = Set("css", "css/a.css", "js", "js/a.js", "js/a.js.gz")
+val expected = Set(
+  "css", "css/a.css",
+  "js", "js/a.js", "js/a.js.gz"
+) map(_.replace("/", java.io.File.separator))
 
 val checkMappings = taskKey[Unit]("check the pipeline mappings")
 


### PR DESCRIPTION
I had an issue in the last pull request as I was using `java.nio.file.Paths` which worked on my local Ubuntu but not on Travis as is not available in JDK6
